### PR TITLE
fix: invalid webpack devtool option value

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
 module.exports = (env = {}) => ({
   mode: env.prod ? 'production' : 'development',
-  devtool: env.prod ? 'source-map' : 'cheap-module-eval-source-map',
+  devtool: env.prod ? 'source-map' : 'eval-cheap-module-source-map',
   entry: path.resolve(__dirname, './src/main.js'),
   output: {
     path: path.resolve(__dirname, './dist'),


### PR DESCRIPTION
'cheap-module-eval-source-map' is not a valid webpack devtool option.
see: https://webpack.js.org/configuration/devtool/

I guess correct option is 'eval-cheap-module-source-map'.
